### PR TITLE
升级到 Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ outputs:
     description: "The release commit"
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "lib/index.js"
 
 # env:


### PR DESCRIPTION
GitHub 最近要求升级 Node.js，将在今年6月2号强制使用 Node.js 24 来运行 Actions，并在今年9月16号从 runner 实例中移除 Node.js 20：

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: xresloader/upload-to-github-release@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

以及，感谢作者，这个 action 最直观好用了 >_<